### PR TITLE
Make sha256 platform-pluggable for browser builds

### DIFF
--- a/apidocs/functions/getTokenProvider.md
+++ b/apidocs/functions/getTokenProvider.md
@@ -6,13 +6,13 @@
 
 # Function: getTokenProvider()
 
-> **getTokenProvider**(`config`): () => `Promise`\<`string`\>
+> **getTokenProvider**(`config?`): () => `Promise`\<`string`\>
 
 Creates a reusable token provider function with the specified configuration.
 
 ## Parameters
 
-### config
+### config?
 
 [`GetTokenProviderConfig`](../interfaces/GetTokenProviderConfig.md) = `{}`
 
@@ -22,11 +22,7 @@ Configuration options for the token provider
 
 An async function that generates AWS Bedrock API tokens when called
 
-> (): `Promise`\<`string`\>
-
-### Returns
-
-`Promise`\<`string`\>
+() => `Promise`\<`string`\>
 
 ## See
 

--- a/apidocs/interfaces/GetTokenConfig.md
+++ b/apidocs/interfaces/GetTokenConfig.md
@@ -25,7 +25,7 @@ Can be either static credentials or a credentials provider function.
 
 ### expiresInSeconds?
 
-> `optional` **expiresInSeconds**: `number`
+> `optional` **expiresInSeconds?**: `number`
 
 Token expiration time in seconds. The expiration can be configured up to a maximum of 12 hours.
 However, the actual token validity period will always be the minimum of the requested expiration time
@@ -44,3 +44,12 @@ and the AWS credentials' expiry time.
 > **region**: `string`
 
 AWS region to use for the token (e.g., "us-west-2").
+
+***
+
+### sha256?
+
+> `optional` **sha256?**: `ChecksumConstructor`
+
+SHA-256 implementation used by SignatureV4. Defaults to the platform-native
+implementation.

--- a/apidocs/interfaces/GetTokenProviderConfig.md
+++ b/apidocs/interfaces/GetTokenProviderConfig.md
@@ -16,7 +16,7 @@ Configuration options for creating a reusable AWS Bedrock API token provider.
 
 ### credentials?
 
-> `optional` **credentials**: `AwsCredentialIdentity` \| `AwsCredentialIdentityProvider`
+> `optional` **credentials?**: `AwsCredentialIdentity` \| `AwsCredentialIdentityProvider`
 
 AWS credentials to use for signing.
 Can be either static credentials or a credentials provider function.
@@ -27,13 +27,13 @@ Can be either static credentials or a credentials provider function.
 
 #### Inherited from
 
-`Partial.credentials`
+[`GetTokenConfig`](GetTokenConfig.md).[`credentials`](GetTokenConfig.md#credentials)
 
 ***
 
 ### expiresInSeconds?
 
-> `optional` **expiresInSeconds**: `number`
+> `optional` **expiresInSeconds?**: `number`
 
 Token expiration time in seconds. The expiration can be configured up to a maximum of 12 hours.
 However, the actual token validity period will always be the minimum of the requested expiration time
@@ -47,13 +47,13 @@ and the AWS credentials' expiry time.
 
 #### Inherited from
 
-`Partial.expiresInSeconds`
+[`GetTokenConfig`](GetTokenConfig.md).[`expiresInSeconds`](GetTokenConfig.md#expiresinseconds)
 
 ***
 
 ### profile?
 
-> `optional` **profile**: `string`
+> `optional` **profile?**: `string`
 
 AWS profile name to use when loading credentials from shared config.
 
@@ -61,10 +61,23 @@ AWS profile name to use when loading credentials from shared config.
 
 ### region?
 
-> `optional` **region**: `string`
+> `optional` **region?**: `string`
 
 AWS region to use for the token (e.g., "us-west-2").
 
 #### Inherited from
 
-`Partial.region`
+[`GetTokenConfig`](GetTokenConfig.md).[`region`](GetTokenConfig.md#region)
+
+***
+
+### sha256?
+
+> `optional` **sha256?**: `ChecksumConstructor`
+
+SHA-256 implementation used by SignatureV4. Defaults to the platform-native
+implementation.
+
+#### Inherited from
+
+[`GetTokenConfig`](GetTokenConfig.md).[`sha256`](GetTokenConfig.md#sha256)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "clean": "rm -rf dist",
+    "prepare": "tsc",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
@@ -46,6 +47,7 @@
     "./dist/runtimeConfig": "./dist/runtimeConfig.browser"
   },
   "dependencies": {
+    "@aws-crypto/sha256-browser": "^5.2.0",
     "@aws-sdk/credential-providers": "^3.525.0",
     "@aws-sdk/util-format-url": ">=3.525.0",
     "@smithy/config-resolver": "^4.1.4",

--- a/src/getToken.spec.ts
+++ b/src/getToken.spec.ts
@@ -51,7 +51,7 @@ describe("getToken", () => {
     );
   });
 
-  it("should call createToken with the provided config", async () => {
+  it("should call createToken with the resolved config", async () => {
     const config: GetTokenConfig = {
       credentials: MOCK_CREDENTIALS,
       region: MOCK_REGION,
@@ -60,7 +60,10 @@ describe("getToken", () => {
 
     await getToken(config);
 
-    expect(tokenModule.createToken).toHaveBeenCalledWith(config);
+    expect(tokenModule.createToken).toHaveBeenCalledWith({
+      ...config,
+      sha256: expect.any(Function),
+    });
   });
 
   it("should return the token from createToken", async () => {
@@ -84,7 +87,10 @@ describe("getToken", () => {
 
     await getToken(config);
 
-    expect(tokenModule.createToken).toHaveBeenCalledWith(config);
+    expect(tokenModule.createToken).toHaveBeenCalledWith({
+      ...config,
+      sha256: expect.any(Function),
+    });
   });
 
   it("should propagate errors from validateTokenExpiryInput", async () => {

--- a/src/getToken.ts
+++ b/src/getToken.ts
@@ -6,8 +6,10 @@
 import {
   AwsCredentialIdentity,
   AwsCredentialIdentityProvider,
+  ChecksumConstructor,
 } from "@smithy/types";
 import { createToken, validateTokenExpiryInput } from "./token";
+import { getCreateTokenConfig } from "./runtimeConfig";
 
 /**
  * Configuration options for generating an AWS Bedrock API token.
@@ -32,6 +34,12 @@ export interface GetTokenConfig {
    * @default 43200 (12 hour)
    */
   expiresInSeconds?: number;
+
+  /**
+   * SHA-256 implementation used by SignatureV4. Defaults to the platform-native
+   * implementation.
+   */
+  sha256?: ChecksumConstructor;
 }
 
 /**
@@ -48,5 +56,5 @@ export interface GetTokenConfig {
  */
 export const getToken = async (config: GetTokenConfig): Promise<string> => {
   validateTokenExpiryInput(config.expiresInSeconds);
-  return createToken(config);
+  return createToken(getCreateTokenConfig(config));
 };

--- a/src/runtimeConfig.browser.spec.ts
+++ b/src/runtimeConfig.browser.spec.ts
@@ -42,6 +42,7 @@ describe("runtimeConfig.browser", () => {
       credentials: MOCK_CREDENTIALS,
       region: MOCK_REGION,
       expiresInSeconds: 7200,
+      sha256: expect.any(Function),
     });
 
     // Verify invalidProvider was not called

--- a/src/runtimeConfig.browser.ts
+++ b/src/runtimeConfig.browser.ts
@@ -4,6 +4,7 @@
  */
 
 import { invalidProvider } from "@smithy/invalid-dependency";
+import { Sha256 } from "@aws-crypto/sha256-browser";
 import { CreateTokenConfig } from "./token";
 import { GetTokenProviderConfig } from "./getTokenProvider";
 
@@ -17,5 +18,6 @@ export const getCreateTokenConfig = (
     ...config,
     credentials: config.credentials ?? invalidProvider("Credential is missing"),
     region: config.region ?? invalidProvider("Region is missing"),
+    sha256: config.sha256 ?? Sha256,
   };
 };

--- a/src/runtimeConfig.spec.ts
+++ b/src/runtimeConfig.spec.ts
@@ -62,6 +62,7 @@ describe("runtimeConfig", () => {
       credentials: MOCK_CREDENTIALS,
       region: MOCK_REGION,
       expiresInSeconds: 7200,
+      sha256: expect.any(Function),
     });
 
     // Verify provider functions were not called
@@ -79,6 +80,7 @@ describe("runtimeConfig", () => {
     expect(result).toEqual({
       credentials: MOCK_PROVIDER_CHAIN_CREDENTIALS,
       region: MOCK_REGION,
+      sha256: expect.any(Function),
     });
 
     expect(fromNodeProviderChain).toHaveBeenCalledWith({

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -9,6 +9,8 @@ import {
   NODE_REGION_CONFIG_FILE_OPTIONS,
   NODE_REGION_CONFIG_OPTIONS,
 } from "@smithy/config-resolver";
+import { Hash } from "@smithy/hash-node";
+import { ChecksumConstructor } from "@smithy/types";
 import { GetTokenProviderConfig } from "./getTokenProvider";
 import { CreateTokenConfig } from "./token";
 
@@ -31,5 +33,6 @@ export const getCreateTokenConfig = (
         ...NODE_REGION_CONFIG_FILE_OPTIONS,
         profile: config.profile,
       }),
+    sha256: config.sha256 ?? (Hash.bind(null, "sha256") as ChecksumConstructor),
   };
 };

--- a/src/token.spec.ts
+++ b/src/token.spec.ts
@@ -6,11 +6,13 @@ import { SignatureV4 } from "@smithy/signature-v4";
 import { formatUrl } from "@aws-sdk/util-format-url";
 import { HttpRequest } from "@smithy/protocol-http";
 import { createToken, validateTokenExpiryInput } from "./token";
-import { AwsCredentialIdentity } from "@smithy/types";
+import { AwsCredentialIdentity, ChecksumConstructor } from "@smithy/types";
 
 jest.mock("@smithy/signature-v4");
 jest.mock("@aws-sdk/util-format-url");
 jest.mock("@smithy/protocol-http");
+
+const MOCK_SHA256 = jest.fn() as unknown as ChecksumConstructor;
 
 describe("token", () => {
   describe("createToken", () => {
@@ -44,13 +46,14 @@ describe("token", () => {
       const token = await createToken({
         credentials: MOCK_CREDENTIALS,
         region: MOCK_REGION,
+        sha256: MOCK_SHA256,
       });
 
       expect(SignatureV4).toHaveBeenCalledWith({
         service: "bedrock",
         region: MOCK_REGION,
         credentials: MOCK_CREDENTIALS,
-        sha256: expect.any(Function),
+        sha256: MOCK_SHA256,
       });
 
       // Verify presign was called with correct parameters
@@ -93,6 +96,7 @@ describe("token", () => {
         credentials: MOCK_CREDENTIALS,
         region: MOCK_REGION,
         expiresInSeconds: customExpiryTime,
+        sha256: MOCK_SHA256,
       });
 
       expect(mockPresign).toHaveBeenCalledWith(expect.any(Object), {
@@ -106,6 +110,7 @@ describe("token", () => {
       await createToken({
         credentials: credentialProvider,
         region: MOCK_REGION,
+        sha256: MOCK_SHA256,
       });
 
       // Verify SignatureV4 constructor was called with the credential provider
@@ -113,7 +118,7 @@ describe("token", () => {
         service: "bedrock",
         region: MOCK_REGION,
         credentials: credentialProvider,
-        sha256: expect.any(Function),
+        sha256: MOCK_SHA256,
       });
     });
 
@@ -123,6 +128,7 @@ describe("token", () => {
       await createToken({
         credentials: MOCK_CREDENTIALS,
         region: regionProvider,
+        sha256: MOCK_SHA256,
       });
 
       // Verify SignatureV4 constructor was called with the region provider
@@ -130,7 +136,7 @@ describe("token", () => {
         service: "bedrock",
         region: regionProvider,
         credentials: MOCK_CREDENTIALS,
-        sha256: expect.any(Function),
+        sha256: MOCK_SHA256,
       });
     });
 
@@ -143,6 +149,7 @@ describe("token", () => {
       const token = await createToken({
         credentials: MOCK_CREDENTIALS,
         region: MOCK_REGION,
+        sha256: MOCK_SHA256,
       });
 
       // Expected encoded value (without protocol prefix)
@@ -163,6 +170,7 @@ describe("token", () => {
       const token = await createToken({
         credentials: MOCK_CREDENTIALS,
         region: MOCK_REGION,
+        sha256: MOCK_SHA256,
       });
 
       // Decode the token and verify it doesn't contain the protocol prefix

--- a/src/token.ts
+++ b/src/token.ts
@@ -10,7 +10,6 @@ import {
   Provider,
 } from "@smithy/types";
 import { SignatureV4 } from "@smithy/signature-v4";
-import { Hash } from "@smithy/hash-node";
 import { HttpRequest } from "@smithy/protocol-http";
 import { formatUrl } from "@aws-sdk/util-format-url";
 
@@ -31,6 +30,7 @@ export interface CreateTokenConfig {
   expiresInSeconds?: number;
   credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider;
   region: string | Provider<string>;
+  sha256: ChecksumConstructor;
 }
 
 /**
@@ -45,7 +45,7 @@ export const createToken = async (
     service: SERVICE_NAME,
     region: config.region,
     credentials: config.credentials,
-    sha256: Hash.bind(null, "sha256") as ChecksumConstructor,
+    sha256: config.sha256,
   });
 
   const request = new HttpRequest({


### PR DESCRIPTION
`token.ts` hard-imports `@smithy/hash-node`, which calls `require('crypto')`, so the package fails to bundle on browser builds and on JS runtimes with no `node:crypto`. This threads sha256 through `runtimeConfig` instead, matching the shape AWS SDK clients use, with the node default unchanged and a `@aws-crypto/sha256-browser` default in the browser variant.

All tests green locally.