### PR TITLE
Add refreshing Bedrock token provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ import { getTokenProvider } from "@aws/bedrock-token-generator";
 const provideToken = getTokenProvider();
 
 async function example() {
-    
   const token = await provideToken();
 
   // Use the token for API calls. The token has a default expiration of 12 hour.
-  // If the expiresInSeconds parameter is specified during token creation, the 
-  // expiration can be configured up to a maximum of 12 hours. However, the actual 
-  // token validity period will always be the minimum of the requested expiration 
+  // If the expiresInSeconds parameter is specified during token creation, the
+  // expiration can be configured up to a maximum of 12 hours. However, the actual
+  // token validity period will always be the minimum of the requested expiration
   // time and the AWS credentials' expiry time
   console.log(`Bearer Token: ${token}`);
 }
@@ -64,13 +63,12 @@ const provideToken = getTokenProvider({
 });
 
 async function example() {
-    
   const token = await provideToken();
 
   // Use the token for API calls. The token has a default expiration of 12 hour.
-  // If the expiresInSeconds parameter is specified during token creation, the 
-  // expiration can be configured up to a maximum of 12 hours. However, the actual 
-  // token validity period will always be the minimum of the requested expiration 
+  // If the expiresInSeconds parameter is specified during token creation, the
+  // expiration can be configured up to a maximum of 12 hours. However, the actual
+  // token validity period will always be the minimum of the requested expiration
   // time and the AWS credentials' expiry time
   console.log(`Bearer Token: ${token}`);
 }
@@ -99,6 +97,30 @@ async function example() {
   // Use the token for API calls. The token has an expiration of 2 hour. However, the actual token validity period
   // will always be the minimum of the requested expiration time and the AWS credentials' expiry time
   console.log(`Bearer Token: ${token}`);
+}
+```
+
+### Using Refreshing Token Provider
+
+Use `getRefreshingTokenProvider` when an application needs to reuse a provider
+across many requests. It returns a cached token until the token is close to
+expiry, then generates a new token automatically.
+
+```typescript
+import { getRefreshingTokenProvider } from "@aws/bedrock-token-generator";
+
+const provideToken = getRefreshingTokenProvider({
+  region: "us-east-1",
+  expiresInSeconds: 7200,
+});
+
+async function example() {
+  const token = await provideToken();
+
+  // To force a refresh after an authentication error:
+  const refreshedToken = await provideToken.refresh();
+
+  console.log(`Bearer Token: ${refreshedToken}`);
 }
 ```
 

--- a/apidocs/README.md
+++ b/apidocs/README.md
@@ -10,10 +10,13 @@
 
 ## Interfaces
 
+- [GetRefreshingTokenProviderConfig](interfaces/GetRefreshingTokenProviderConfig.md)
 - [GetTokenConfig](interfaces/GetTokenConfig.md)
 - [GetTokenProviderConfig](interfaces/GetTokenProviderConfig.md)
+- [RefreshingTokenProvider](interfaces/RefreshingTokenProvider.md)
 
 ## Functions
 
+- [getRefreshingTokenProvider](functions/getRefreshingTokenProvider.md)
 - [getToken](functions/getToken.md)
 - [getTokenProvider](functions/getTokenProvider.md)

--- a/apidocs/functions/getRefreshingTokenProvider.md
+++ b/apidocs/functions/getRefreshingTokenProvider.md
@@ -1,0 +1,37 @@
+[**@aws/bedrock-token-generator**](../README.md)
+
+***
+
+[@aws/bedrock-token-generator](../README.md) / getRefreshingTokenProvider
+
+# Function: getRefreshingTokenProvider()
+
+> **getRefreshingTokenProvider**(`config?`): [`RefreshingTokenProvider`](../interfaces/RefreshingTokenProvider.md)
+
+Creates a reusable token provider that caches tokens until they are close to
+expiry, then automatically generates a replacement token.
+
+## Parameters
+
+### config?
+
+[`GetRefreshingTokenProviderConfig`](../interfaces/GetRefreshingTokenProviderConfig.md) = `{}`
+
+Configuration options for the token provider
+
+## Returns
+
+[`RefreshingTokenProvider`](../interfaces/RefreshingTokenProvider.md)
+
+An async provider function with a `refresh()` method for forced refreshes
+
+## See
+
+[GetRefreshingTokenProviderConfig](../interfaces/GetRefreshingTokenProviderConfig.md)
+
+## Example
+
+```ts
+const provideToken = getRefreshingTokenProvider({ region: "us-east-1" });
+const token = await provideToken();
+```

--- a/apidocs/interfaces/GetRefreshingTokenProviderConfig.md
+++ b/apidocs/interfaces/GetRefreshingTokenProviderConfig.md
@@ -1,0 +1,89 @@
+[**@aws/bedrock-token-generator**](../README.md)
+
+***
+
+[@aws/bedrock-token-generator](../README.md) / GetRefreshingTokenProviderConfig
+
+# Interface: GetRefreshingTokenProviderConfig
+
+Configuration options for creating a cached AWS Bedrock API token provider
+that regenerates tokens before they expire.
+
+## Extends
+
+- [`GetTokenProviderConfig`](GetTokenProviderConfig.md)
+
+## Properties
+
+### credentials?
+
+> `optional` **credentials?**: `AwsCredentialIdentity` \| `AwsCredentialIdentityProvider`
+
+AWS credentials to use for signing.
+Can be either static credentials or a credentials provider function.
+
+#### See
+
+[https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/)
+
+#### Inherited from
+
+[`GetTokenConfig`](GetTokenConfig.md).[`credentials`](GetTokenConfig.md#credentials)
+
+***
+
+### expiresInSeconds?
+
+> `optional` **expiresInSeconds?**: `number`
+
+Token expiration time in seconds. The expiration can be configured up to a maximum of 12 hours.
+However, the actual token validity period will always be the minimum of the requested expiration time
+and the AWS credentials' expiry time.
+
+#### Default
+
+```ts
+43200 (12 hour)
+```
+
+#### Inherited from
+
+[`GetTokenConfig`](GetTokenConfig.md).[`expiresInSeconds`](GetTokenConfig.md#expiresinseconds)
+
+***
+
+### profile?
+
+> `optional` **profile?**: `string`
+
+AWS profile name to use when loading credentials from shared config.
+
+#### Inherited from
+
+[`GetTokenProviderConfig`](GetTokenProviderConfig.md).[`profile`](GetTokenProviderConfig.md#profile)
+
+***
+
+### refreshBeforeExpirySeconds?
+
+> `optional` **refreshBeforeExpirySeconds?**: `number`
+
+How many seconds before expiry the provider should regenerate the token.
+
+#### Default
+
+```ts
+300 (5 minutes)
+```
+
+***
+
+### region?
+
+> `optional` **region?**: `string`
+
+AWS region to use for the token (e.g., "us-west-2").
+
+#### Inherited from
+
+[`GetTokenConfig`](GetTokenConfig.md).[`region`](GetTokenConfig.md#region)

--- a/apidocs/interfaces/RefreshingTokenProvider.md
+++ b/apidocs/interfaces/RefreshingTokenProvider.md
@@ -1,0 +1,29 @@
+[**@aws/bedrock-token-generator**](../README.md)
+
+***
+
+[@aws/bedrock-token-generator](../README.md) / RefreshingTokenProvider
+
+# Interface: RefreshingTokenProvider()
+
+A token provider that caches generated tokens and refreshes them on demand.
+
+> **RefreshingTokenProvider**(): `Promise`\<`string`\>
+
+Returns a cached token when it is still valid, otherwise generates a new one.
+
+## Returns
+
+`Promise`\<`string`\>
+
+## Methods
+
+### refresh()
+
+> **refresh**(): `Promise`\<`string`\>
+
+Forces token regeneration and updates the cached token.
+
+#### Returns
+
+`Promise`\<`string`\>

--- a/src/getRefreshingTokenProvider.spec.ts
+++ b/src/getRefreshingTokenProvider.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getRefreshingTokenProvider,
+  GetRefreshingTokenProviderConfig,
+} from "./getRefreshingTokenProvider";
+import { AwsCredentialIdentity } from "@smithy/types";
+
+jest.mock("./token", () => ({
+  createToken: jest.fn(),
+  validateTokenExpiryInput: jest.fn(),
+}));
+
+jest.mock("./runtimeConfig", () => ({
+  getCreateTokenConfig: jest.fn(),
+}));
+
+import * as tokenModule from "./token";
+import * as runtimeConfigModule from "./runtimeConfig";
+
+const MOCK_REGION = "us-west-2";
+const MOCK_CREDENTIALS: AwsCredentialIdentity = {
+  accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+};
+const START_TIME = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+const createMockToken = (
+  amzDate = "20260101T000000Z",
+  expiresInSeconds = 3600,
+) => {
+  const presignedUrl =
+    `bedrock.amazonaws.com/?Action=CallWithBearerToken` +
+    `&X-Amz-Date=${amzDate}` +
+    `&X-Amz-Expires=${expiresInSeconds}` +
+    `&X-Amz-SignedHeaders=host` +
+    `&X-Amz-Signature=abcdef1234567890` +
+    `&Version=1`;
+  return `bedrock-api-key-${Buffer.from(presignedUrl, "utf-8").toString("base64")}`;
+};
+
+describe("getRefreshingTokenProvider", () => {
+  const mockRuntimeCreateConfig = {
+    credentials: MOCK_CREDENTIALS,
+    region: MOCK_REGION,
+    expiresInSeconds: 3600,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME);
+
+    (tokenModule.createToken as jest.Mock).mockResolvedValue(createMockToken());
+    (runtimeConfigModule.getCreateTokenConfig as jest.Mock).mockReturnValue(
+      mockRuntimeCreateConfig,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should validate expiresInSeconds during initialization", () => {
+    const config: GetRefreshingTokenProviderConfig = {
+      expiresInSeconds: 7200,
+    };
+
+    getRefreshingTokenProvider(config);
+
+    expect(tokenModule.validateTokenExpiryInput).toHaveBeenCalledWith(7200);
+  });
+
+  it("should reject negative refreshBeforeExpirySeconds", () => {
+    expect(() =>
+      getRefreshingTokenProvider({ refreshBeforeExpirySeconds: -1 }),
+    ).toThrow("RefreshBeforeExpirySeconds must be non-negative.");
+  });
+
+  it("should return cached token while it is not near expiry", async () => {
+    const provideToken = getRefreshingTokenProvider({
+      refreshBeforeExpirySeconds: 60,
+    });
+
+    const firstToken = await provideToken();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME + 10_000);
+    const secondToken = await provideToken();
+
+    expect(firstToken).toBe(secondToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should refresh when the cached token is expired", async () => {
+    (tokenModule.createToken as jest.Mock)
+      .mockResolvedValueOnce(createMockToken("20260101T000000Z", 1))
+      .mockResolvedValueOnce(createMockToken("20260101T000002Z", 3600));
+
+    const provideToken = getRefreshingTokenProvider({
+      refreshBeforeExpirySeconds: 0,
+    });
+
+    const firstToken = await provideToken();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME + 2_000);
+    const secondToken = await provideToken();
+
+    expect(firstToken).not.toBe(secondToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("should refresh when the token enters the refresh window", async () => {
+    (tokenModule.createToken as jest.Mock)
+      .mockResolvedValueOnce(createMockToken("20260101T000000Z", 10))
+      .mockResolvedValueOnce(createMockToken("20260101T000006Z", 10));
+
+    const provideToken = getRefreshingTokenProvider({
+      refreshBeforeExpirySeconds: 5,
+    });
+
+    const firstToken = await provideToken();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME + 4_000);
+    const stillCachedToken = await provideToken();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME + 6_000);
+    const refreshedToken = await provideToken();
+
+    expect(stillCachedToken).toBe(firstToken);
+    expect(refreshedToken).not.toBe(firstToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use credential expiration when it is earlier than token expiration", async () => {
+    (tokenModule.createToken as jest.Mock)
+      .mockResolvedValueOnce(createMockToken("20260101T000000Z", 3600))
+      .mockResolvedValueOnce(createMockToken("20260101T000011Z", 3600));
+    const expiringCredentials = {
+      ...MOCK_CREDENTIALS,
+      expiration: new Date(START_TIME + 10_000),
+    };
+    (runtimeConfigModule.getCreateTokenConfig as jest.Mock).mockReturnValue({
+      credentials: expiringCredentials,
+      region: MOCK_REGION,
+      expiresInSeconds: 3600,
+    });
+
+    const provideToken = getRefreshingTokenProvider({
+      refreshBeforeExpirySeconds: 0,
+    });
+
+    const firstToken = await provideToken();
+    jest.spyOn(Date, "now").mockReturnValue(START_TIME + 11_000);
+    const secondToken = await provideToken();
+
+    expect(firstToken).not.toBe(secondToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("should only create one token for concurrent refreshes", async () => {
+    let resolveToken: (value: string) => void = () => {};
+    (tokenModule.createToken as jest.Mock).mockReturnValue(
+      new Promise((resolve) => {
+        resolveToken = resolve;
+      }),
+    );
+
+    const provideToken = getRefreshingTokenProvider();
+    const firstCall = provideToken();
+    const secondCall = provideToken();
+    resolveToken(createMockToken());
+
+    const [firstToken, secondToken] = await Promise.all([
+      firstCall,
+      secondCall,
+    ]);
+
+    expect(firstToken).toBe(secondToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("should force refresh when refresh is called", async () => {
+    (tokenModule.createToken as jest.Mock)
+      .mockResolvedValueOnce(createMockToken("20260101T000000Z", 3600))
+      .mockResolvedValueOnce(createMockToken("20260101T000100Z", 3600));
+
+    const provideToken = getRefreshingTokenProvider();
+
+    const firstToken = await provideToken();
+    const refreshedToken = await provideToken.refresh();
+    const cachedToken = await provideToken();
+
+    expect(refreshedToken).not.toBe(firstToken);
+    expect(cachedToken).toBe(refreshedToken);
+    expect(tokenModule.createToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("should propagate errors from createToken", async () => {
+    const createTokenError = new Error("Token creation failed");
+    (tokenModule.createToken as jest.Mock).mockRejectedValueOnce(
+      createTokenError,
+    );
+
+    const provideToken = getRefreshingTokenProvider();
+    await expect(provideToken()).rejects.toThrow(createTokenError);
+  });
+});

--- a/src/getRefreshingTokenProvider.ts
+++ b/src/getRefreshingTokenProvider.ts
@@ -1,0 +1,218 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AwsCredentialIdentity, Provider } from "@smithy/types";
+import { GetTokenProviderConfig } from "./getTokenProvider";
+import {
+  createToken,
+  CreateTokenConfig,
+  validateTokenExpiryInput,
+} from "./token";
+import { getCreateTokenConfig } from "./runtimeConfig";
+
+const DEFAULT_REFRESH_BEFORE_EXPIRY_SECONDS = 300; // 5 minutes in seconds
+const AUTH_PREFIX = "bedrock-api-key-";
+
+/**
+ * Configuration options for creating a cached AWS Bedrock API token provider
+ * that regenerates tokens before they expire.
+ */
+export interface GetRefreshingTokenProviderConfig extends GetTokenProviderConfig {
+  /**
+   * How many seconds before expiry the provider should regenerate the token.
+   * @default 300 (5 minutes)
+   */
+  refreshBeforeExpirySeconds?: number;
+}
+
+/**
+ * A token provider that caches generated tokens and refreshes them on demand.
+ */
+export interface RefreshingTokenProvider {
+  /**
+   * Returns a cached token when it is still valid, otherwise generates a new one.
+   */
+  (): Promise<string>;
+
+  /**
+   * Forces token regeneration and updates the cached token.
+   */
+  refresh(): Promise<string>;
+}
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+/**
+ * Creates a reusable token provider that caches tokens until they are close to
+ * expiry, then automatically generates a replacement token.
+ *
+ * @param config - Configuration options for the token provider @see {@link GetRefreshingTokenProviderConfig}
+ * @returns An async provider function with a `refresh()` method for forced refreshes
+ *
+ * @example
+ * const provideToken = getRefreshingTokenProvider({ region: "us-east-1" });
+ * const token = await provideToken();
+ */
+export const getRefreshingTokenProvider = (
+  config: GetRefreshingTokenProviderConfig = {},
+): RefreshingTokenProvider => {
+  validateTokenExpiryInput(config.expiresInSeconds);
+  validateRefreshBeforeExpiryInput(config.refreshBeforeExpirySeconds);
+
+  const refreshBeforeExpirySeconds =
+    config.refreshBeforeExpirySeconds ?? DEFAULT_REFRESH_BEFORE_EXPIRY_SECONDS;
+
+  let createTokenConfig: CreateTokenConfig;
+  let cache: TokenCache | undefined;
+  let refreshPromise: Promise<string> | undefined;
+
+  const refresh = async (): Promise<string> => {
+    if (!createTokenConfig) {
+      createTokenConfig = getCreateTokenConfig(config);
+    }
+
+    const { token, expiresAt } =
+      await createTokenWithExpiration(createTokenConfig);
+    cache = { token, expiresAt };
+    return token;
+  };
+
+  const provider = (async (): Promise<string> => {
+    if (cache && !shouldRefresh(cache, refreshBeforeExpirySeconds)) {
+      return cache.token;
+    }
+
+    refreshPromise ??= refresh().finally(() => {
+      refreshPromise = undefined;
+    });
+
+    return refreshPromise;
+  }) as RefreshingTokenProvider;
+
+  provider.refresh = async (): Promise<string> => {
+    refreshPromise = refresh().finally(() => {
+      refreshPromise = undefined;
+    });
+
+    return refreshPromise;
+  };
+
+  return provider;
+};
+
+const shouldRefresh = (
+  cache: TokenCache,
+  refreshBeforeExpirySeconds: number,
+): boolean => cache.expiresAt - refreshBeforeExpirySeconds * 1000 <= Date.now();
+
+const createTokenWithExpiration = async (
+  config: CreateTokenConfig,
+): Promise<TokenCache> => {
+  const credentials = await resolveProvider(config.credentials);
+  const region = await resolveProvider(config.region);
+  const token = await createToken({
+    ...config,
+    credentials,
+    region,
+  });
+  const expiresAt = getTokenExpiration(token, credentials);
+
+  if (expiresAt === undefined) {
+    throw new Error("Unable to determine token expiration.");
+  }
+
+  return { token, expiresAt };
+};
+
+const resolveProvider = async <T>(value: T | Provider<T>): Promise<T> => {
+  if (typeof value === "function") {
+    return (value as Provider<T>)();
+  }
+
+  return value;
+};
+
+const getTokenExpiration = (
+  token: string,
+  credentials: AwsCredentialIdentity,
+): number | undefined => {
+  const tokenExpiration = getPresignedUrlExpiration(token);
+  const credentialExpiration = getCredentialExpiration(credentials);
+
+  if (tokenExpiration !== undefined && credentialExpiration !== undefined) {
+    return Math.min(tokenExpiration, credentialExpiration);
+  }
+
+  return tokenExpiration ?? credentialExpiration;
+};
+
+const getPresignedUrlExpiration = (token: string): number | undefined => {
+  if (!token.startsWith(AUTH_PREFIX)) {
+    return undefined;
+  }
+
+  let url: URL;
+  try {
+    const encoded = token.slice(AUTH_PREFIX.length);
+    const decoded = Buffer.from(encoded, "base64").toString("utf-8");
+    url = new URL(`https://${decoded}`);
+  } catch {
+    return undefined;
+  }
+
+  const amzDate = url.searchParams.get("X-Amz-Date");
+  const expiresInSeconds = Number(url.searchParams.get("X-Amz-Expires"));
+
+  if (!amzDate || !Number.isFinite(expiresInSeconds)) {
+    return undefined;
+  }
+
+  const signedAt = parseAmzDate(amzDate);
+  if (signedAt === undefined) {
+    return undefined;
+  }
+
+  return signedAt + expiresInSeconds * 1000;
+};
+
+const getCredentialExpiration = (
+  credentials: AwsCredentialIdentity,
+): number | undefined => {
+  const expiration = credentials.expiration?.getTime();
+  return expiration !== undefined && Number.isFinite(expiration)
+    ? expiration
+    : undefined;
+};
+
+const parseAmzDate = (value: string): number | undefined => {
+  const match = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/.exec(value);
+  if (!match) {
+    return undefined;
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  return Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+  );
+};
+
+const validateRefreshBeforeExpiryInput = (
+  refreshBeforeExpirySeconds?: number,
+) => {
+  if (
+    refreshBeforeExpirySeconds !== undefined &&
+    refreshBeforeExpirySeconds < 0
+  ) {
+    throw new Error("RefreshBeforeExpirySeconds must be non-negative.");
+  }
+};

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,8 +6,8 @@
 import * as bedrockTokenGenerator from "./index";
 
 describe("@aws/bedrock-token-generator", () => {
-  it("has three exports", () => {
-    expect(Object.keys(bedrockTokenGenerator).length).toBe(3);
+  it("has four exports", () => {
+    expect(Object.keys(bedrockTokenGenerator).length).toBe(4);
   });
 
   it("exports getToken", () => {
@@ -16,6 +16,10 @@ describe("@aws/bedrock-token-generator", () => {
 
   it("exports getTokenProvider", () => {
     expect(bedrockTokenGenerator.getTokenProvider).toBeDefined();
+  });
+
+  it("exports getRefreshingTokenProvider", () => {
+    expect(bedrockTokenGenerator.getRefreshingTokenProvider).toBeDefined();
   });
 
   it("exports BedrockTokenGenerator", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,8 @@
 export { BedrockTokenGenerator } from "./BedrockTokenGenerator";
 export { getToken, GetTokenConfig } from "./getToken";
 export { getTokenProvider, GetTokenProviderConfig } from "./getTokenProvider";
+export {
+  getRefreshingTokenProvider,
+  GetRefreshingTokenProviderConfig,
+  RefreshingTokenProvider,
+} from "./getRefreshingTokenProvider";


### PR DESCRIPTION
 ## Summary
  - Add `getRefreshingTokenProvider()` for cached Bedrock bearer token reuse
  - Refresh tokens before SigV4 token expiry or AWS credential expiry
  - Add `refresh()` for forced token regeneration after auth failures
  - Add tests, README example, and generated API docs

  ## Testing
  - `npm test -- --runInBand`
  - `npm run build`

  ## Note
  - `npm run lint` is not runnable in this repo currently because no ESLint config is present.